### PR TITLE
Page 44 : correction de l'exemple pour cocov[c]

### DIFF
--- a/resumes/anthony_rouneau/src/Chapters_Summary.tex
+++ b/resumes/anthony_rouneau/src/Chapters_Summary.tex
@@ -2067,8 +2067,8 @@
 								&T = cover(i \cup s) \}
 						\end{align*}}
 						Exemple, dans la figure \ref{fig:transactions}, \\
-						  & $cocov[c] =  \{ (a, \{4, 8, 9\}),
-								(b,\ \{2, 5, 8, 9\})\}$\\
+						  & $cocov[c] =  \{ (a, \{4, 5, 8, 9\}),
+								(b,\ \{2, 5, 8\})\}$\\
 						  & $cocov[be] = \{ (a,\ \{1\})\}$
 			\end{tabular}~\\~\\~\\
 			%


### PR DESCRIPTION
A moins que je n'ai pas bien compris la définition de cocov, l'exemple pour cocov[c] était incorrect, si tu  (@Angeall) pouvais checker ;)
Note : Pour éviter de DL les 46 plugins latex, je n'ai pas recompilé le pdf.
